### PR TITLE
[NEW] Add a script to select and change port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,15 @@
 # RC4Conferences
 A set of scalable components for communities to build, manage, and run virtual conferences of any size.
 
-<h2 align='center'>🚀 Developer quick start 🚀</h2>
+<h2 align='center'>🚀 Developer lightning quick start 🚀</h2>
 <p align='center'> Development - Build - Production </p>
 
-## 💻 Developers Quick Start
-
-
-### Start Backend (Open Event Server + Fauna based Superprofile)
-
-To start both the backend together in the root directory (`/RC4Conferences`), run
+To start the development environment simply run the following, the script would handle all process and would output error if there is any, or else you'll be good to start developing.
 ```
-sh startBackend.sh
+sh startdevenv.sh
 ```
 (Currently, for development purpose we are using defult secret values)
 > For production deployments, please change the secret values in `open-event-server/.env.example` and ``open-event-server/.env.dev.app``
-
-### Start Strapi CMS
-```
-cd cms
-npm i
-INITIALIZE_DATA=true npm run develop
-```
-
-The application is written on nextjs and deployable on all nextjs compatible CDN + microservices and scaled deployment platforms. For build and design, start it in a shell:
-```
-cd app
-```
-> If you are running the application on a different port (say on `3001`), then please run
-```
-export NEXT_PUBLIC_PORT=3001
-```
-
-```
-npm i
-npm run dev
-```
 
 ### Route Details
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,23 @@ To start the development environment simply run the following, the script would 
 ```
 sh startdevenv.sh
 ```
-(Currently, for development purpose we are using defult secret values)
+Development Info:
+1. The Strapi admin portal would be opnened by default while starting the development setup.
+2. The NextJS url would be shown in the logs for reference
+```
+> rc4community@0.3.0 dev
+> next dev
+
+
+> backend@0.1.0 build
+> strapi build
+
+ready - started server on 0.0.0.0:3000, url: http://localhost:3000 <-- your NextJS locahost url
+
+```
+3. On visiting the NextJS app localhost url first time, first login using the dummy login button, then do a refresh to load the admin menu.
+(Currently, for development purpose we are using defult secret values).
+
 > For production deployments, please change the secret values in `open-event-server/.env.example` and ``open-event-server/.env.dev.app``
 
 ### Route Details

--- a/cms/src/fetchData.js
+++ b/cms/src/fetchData.js
@@ -26,9 +26,9 @@ module.exports = async () => {
       .count();
     var guidesCount = await strapi.db.query("api::guide.guide").count();
     var formCount = await strapi.db.query("api::form.form").count();
-    var ghrepos = await strapi.db
-      .query("api::github-repository.github-repository")
-      .count({});
+    // var ghrepos = await strapi.db
+    //   .query("api::github-repository.github-repository")
+    //   .count({});
     var speakersCount = await strapi.db.query("api::speaker.speaker").count({});
     console.log("topnv", topNavItemCount)
     // initial fetch

--- a/open-event-server/.gitignore
+++ b/open-event-server/.gitignore
@@ -1,1 +1,2 @@
 err_log.txt
+init_flag

--- a/open-event-server/startOes.sh
+++ b/open-event-server/startOes.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
 ERR_LOG="please check err_log.txt file for more details";
 ERR_FILE="log/err_log.txt"
+INIT_FLAG="log/init_flag"
+OES_CONTAINER_ID=$( docker ps -q -f name=opev-web )
+
+if [ -e $INIT_FLAG ] && [ ! -z $OES_CONTAINER_ID ]; then
+    echo "-- Open Event Server is already up and running --"
+    exit 0
+fi
 
 if [ -s $ERR_FILE ]; then
     rm -r -f log/*
@@ -18,3 +25,7 @@ docker compose up -d
 
 echo "--Copying default environment variables to app/.env--"
 cat .env.dev.app >> ../app/.env
+
+if [ ! -s $ERR_FILE ]; then
+    touch $INIT_FLAG
+fi

--- a/startBackend.sh
+++ b/startBackend.sh
@@ -13,12 +13,12 @@ sh initFaunaOnce.sh
 cd ..
 
 if [ -s $ERR_FILE ];then
-    echo "***Some error occurred while starting the Open Event Server please check open-event-server/$ERR_FILE , resolve them, and then re-run the init command***"
+    echo "\033[31m***Some error occurred while starting the Open Event Server please check open-event-server/$ERR_FILE , resolve them, and then re-run the init command***\e[0m"
 fi
 if [ -z $OES_CONTAINER_ID ]; then
-    echo "***Open-event-server Docker container was unable to install and start, please rerun the script***"
+    echo "\033[31m***Open-event-server Docker container was unable to install and start, please rerun the script***\e[0m"
 fi
 if [ -z $FAUNA_CONTAINER_ID ]; then
     echo $FAUNA_CONTAINER_ID
-    echo "***FaunaDB container was unable to install and start, please rerun the script***"
+    echo "\033[31m***FaunaDB container was unable to install and start, please rerun the script***\e[0m"
 fi

--- a/startBackend.sh
+++ b/startBackend.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 ERR_FILE=open-event-server/log/err_log.txt
+OES_CONTAINER_ID=$( docker ps -q -f name=opev-web )
+FAUNA_CONTAINER_ID=$( docker ps -q -f name=faunadb )
+
 echo "--Starting the Open Event server--"
 cd open-event-server
 sh startOes.sh
@@ -9,15 +12,13 @@ cd ../superprofile
 sh initFaunaOnce.sh
 cd ..
 
-OES_CONTAINER_ID=$( docker ps -q -f name=opev-web )
-FAUNA_CONTAINER_ID=$( docker ps -q -f name=faunadb )
-
 if [ -s $ERR_FILE ];then
     echo "***Some error occurred while starting the Open Event Server please check open-event-server/$ERR_FILE , resolve them, and then re-run the init command***"
 fi
 if [ -z $OES_CONTAINER_ID ]; then
-    echo "***Open-event-server Docker container was unable to install and start***"
+    echo "***Open-event-server Docker container was unable to install and start, please rerun the script***"
 fi
-if [ -z "$FAUNA_CONTAINER_ID" ]; then
-    echo "***FaunaDB container was unable to install and start***"
+if [ -z $FAUNA_CONTAINER_ID ]; then
+    echo $FAUNA_CONTAINER_ID
+    echo "***FaunaDB container was unable to install and start, please rerun the script***"
 fi

--- a/startdevenv.sh
+++ b/startdevenv.sh
@@ -44,15 +44,11 @@ check_and_set_next_port
 export NEXT_PUBLIC_PORT=$NEXTJS_PORT
 
 printf '\nNEXT_PUBLIC_STRAPI_API_URL'="http://127.0.0.1:$STRAPI_PORT" >> app/.env
-cd cms
+sh strapi.sh $STRAPI_PORT &
+
+cd app
+export PORT=$NEXTJS_PORT
 npm i
-export PORT=$STRAPI_PORT
-npm run build
-INITIALIZE_DATA=true npm run develop 
-&
-cd ..
-&
-cd app &
-npm i &
-npm run dev &
+npm run dev
+
 

--- a/startdevenv.sh
+++ b/startdevenv.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 STRAPI_PORT=1337
 NEXTJS_PORT=3000
 counter=0

--- a/strapi.sh
+++ b/strapi.sh
@@ -1,0 +1,5 @@
+cd cms
+npm i
+export PORT=$1
+npm run build
+INITIALIZE_DATA=true npm run develop 

--- a/superprofile/initFaunaOnce.sh
+++ b/superprofile/initFaunaOnce.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 
 waittime=30
+ALREADY_INITIALIZED="log/init_key_flag"
+
+FAUNA_CONTAINER_ID=$( docker ps -q -f name=faunadb )
+
+if [ -e $ALREADY_INITIALIZED ] && [ ! -z $FAUNA_CONTAINER_ID ]; then
+    echo "-- Superprofile is already up and running --"
+    exit 0
+fi
 
 docker compose up -d
 echo "Waiting $waittime seconds for container to get shipped..."

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,58 @@
+STRAPI_PORT=1337
+NEXTJS_PORT=3000
+counter=0
+watchdog=5
+
+check_and_set_strapi_port() {
+
+    if lsof -Pi :$STRAPI_PORT -sTCP:LISTEN -t >/dev/null && [ "$counter" -lt $watchdog ]; then
+        echo "Strapi port $STRAPI_PORT already occupied, changing to the next consecutive port"
+        STRAPI_PORT=$((STRAPI_PORT+1))
+        counter=$((counter+1))
+        check_and_set_strapi_port
+    elif [ "$counter" -ge $watchdog ]; then
+        echo "\033[31m Unable to allocate an empty port for Strapi, the last tried port was $STRAPI_PORT\e[0m"
+        echo "Please either change the $STRAPI_PORT to an other random number or to an unused port number"
+        exit 1
+    else
+        echo "🚀 An empty port found for Strapi🚀"
+    fi
+}
+
+check_and_set_next_port() {
+    if lsof -Pi :$NEXTJS_PORT -sTCP:LISTEN -t >/dev/null && [ "$counter" -lt $watchdog ]; then
+        echo "NextJS port $NEXTJS_PORT already occupied, changing to the next consecutive port"
+        NEXTJS_PORT=$((NEXTJS_PORT+1))
+        counter=$((counter+1))
+        check_and_set_next_port
+    elif [ "$counter" -ge $watchdog ]; then
+        echo "\033[31mUnable to allocate an empty port for NextJS, the last tried port was $NEXTJS_PORT\e[0m"
+        echo "Please either change the $NEXTJS_PORT to an other random number/unused port number"
+        echo "After changes re-run the script"
+        exit 1
+    else
+        echo "🚀 An empty port found for NextJS 🚀"
+    fi
+}
+
+sh startBackend.sh
+
+check_and_set_strapi_port
+counter=0
+check_and_set_next_port
+
+export NEXT_PUBLIC_PORT=$NEXTJS_PORT
+
+printf '\nNEXT_PUBLIC_STRAPI_API_URL'="http://127.0.0.1:$STRAPI_PORT" >> app/.env
+cd cms
+npm i
+export PORT=$STRAPI_PORT
+npm run build
+INITIALIZE_DATA=true npm run develop 
+&
+cd ..
+&
+cd app &
+npm i &
+npm run dev &
+


### PR DESCRIPTION
Changes in the PR:

- [x] An script to select unused ports for NextJS and Strapi.
- [x] Improvement in fauna and OES scripts for better error handling and startup.
- [x] Start Strapi from the script using `&`
- [x] Start NextJS from the script
- [x] Update documentations

Known roadblocks:

- [x] Unable to start both the Strapi and NextJS using the same script since neither of them runs in the background (detached shell).

Thank you!