### PR TITLE
[FIX] Temporary Fix for Gitpod Dev Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ For more detail on how to get ipinfo token and server links, please read [here](
 Once all the environment variables are set run the following script to start the NextJS frontend.
 ```
 sh startNext.sh localhost
+
+sh startNextGp.sh localhost (Only for Gitpod Users)
 ```
 >Note: Please replace the "localhost" with your static IP if you are doing environment setup on your VM.
 

--- a/app/components/menubar.js
+++ b/app/components/menubar.js
@@ -118,12 +118,12 @@ export default function Menubar(props) {
           )}
         </div>
         <div className="mx-2">
-          {/* {hasAllRequiredCreds ? (
+          {hasAllRequiredCreds ? (
             <RocketChatAuthMenuButton />
           ) : (
             <DummyLoginButton />
-          )} */}
-          <RCGoogleLoginButton />
+          )}
+          {/* <RCGoogleLoginButton /> */}
         </div>
       </Navbar>
     </Container>

--- a/app/pages/api/conf/unsignCook.js
+++ b/app/pages/api/conf/unsignCook.js
@@ -3,7 +3,10 @@ import crypto from "crypto-js";
 export default function handler(req, res) {
     if (req.method === 'POST') {
       let hashObject = undefined
-      if (req.body) {
+      if (typeof req.body == Object) {
+        hashObject = req.body
+      }
+      if (typeof req.body == "string") {
         hashObject = JSON.parse(req.body)
       }
       if (!hashObject?.hash) {

--- a/startBackend.sh
+++ b/startBackend.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 ERR_FILE=open-event-server/log/err_log.txt
 INIT_DB=open-event-server/seed/init_db
-OES_CONTAINER_ID=$( docker ps -q -f name=opev-web )
-FAUNA_CONTAINER_ID=$( docker ps -q -f name=faunadb )
+
 
 echo "--Starting the Open Event server--"
 cd open-event-server
@@ -12,6 +11,9 @@ echo "--Starting Superprofile Backend--"
 cd ../superprofile
 sh initFaunaOnce.sh $1
 cd ..
+
+OES_CONTAINER_ID=$( docker ps -q -f name=opev-web )
+FAUNA_CONTAINER_ID=$( docker ps -q -f name=faunadb )
 
 if [ -s $ERR_FILE ];then
     echo "\033[31m***Some error occurred while starting the Open Event Server please check open-event-server/$ERR_FILE , resolve them, and then re-run the init command***\e[0m"

--- a/startNextGp.sh
+++ b/startNextGp.sh
@@ -1,0 +1,32 @@
+NEXTJS_PORT=3000
+
+check_and_set_next_port() {
+    if lsof -Pi :$NEXTJS_PORT -sTCP:LISTEN -t >/dev/null && [ "$counter" -lt $watchdog ]; then
+        echo "NextJS port $NEXTJS_PORT already occupied, changing to the next consecutive port"
+        NEXTJS_PORT=$((NEXTJS_PORT+1))
+        counter=$((counter+1))
+        check_and_set_next_port
+    elif [ "$counter" -ge $watchdog ]; then
+        echo "\033[31mUnable to allocate an empty port for NextJS, the last tried port was $NEXTJS_PORT\e[0m"
+        echo "Please either change the $NEXTJS_PORT to an other random number/unused port number"
+        echo "After changes re-run the script"
+        exit 1
+    else
+        echo "🚀 An empty port found for NextJS 🚀"
+    fi
+}
+check_and_set_next_port
+export NEXT_PUBLIC_API_URL=$(gp url 3000)
+export NEXT_PUBLIC_FAUNA_DOMAIN=$(gp url 8084)/graphql
+gp ports visibility 8084:public
+export NEXT_PUBLIC_EVENT_BACKEND_URL=$(gp url 8080)
+gp ports visibility 8080:public
+
+
+
+export NEXT_PUBLIC_PORT=$NEXTJS_PORT
+printf '\nNEXT_PUBLIC_API_URL'="http://$1:$NEXTJS_PORT" >> app/.env
+
+cd app
+npm i
+npm run dev


### PR DESCRIPTION
The PR fixes the startup script for the Gitpod Dev environment setup. However, this temporary fix needs further investigation and research on recent changes in Gitpod.

Currently, it is only known that any `fetch` request made through the Client Side NextJS App to either Strapi or Superprofile (local Docker) will not be routed internally by Gitpod. So one of the solutions is exporting those Backend URLs and making them public.

The script `startNextGp.sh` is provisional and will be replaced with a Gitpod script(`.yml`). Contributions are welcomed.
Thank you!