### PR TITLE
[FIX] Jitsi unable to start Stream

### DIFF
--- a/app/components/conferences/dayOfEvent/greenroom/Jitsibroadcaster.js
+++ b/app/components/conferences/dayOfEvent/greenroom/Jitsibroadcaster.js
@@ -281,11 +281,14 @@ const Jitsibroadcaster = ({
             p2p: {
               enabled: false,
             },
-            // remoteVideoMenu: {
-            //   disableKick : !isAdmin,
-            //   disableGrantModerator : !isAdmin
-            // },
-            // disableRemoteMute: !isAdmin
+            recordingService: {
+              enabled: true
+            },
+            remoteVideoMenu: {
+              disableKick : !isAdmin,
+              disableGrantModerator : !isAdmin
+            },
+            disableRemoteMute: !isAdmin
           }}
           interfaceConfigOverwrite={{
             DISABLE_JOIN_LEAVE_NOTIFICATIONS: true,


### PR DESCRIPTION
The PR fixes the issue where the stream was not getting started due to the recently introduced new `config` as mentioned [here](https://github.com/jitsi/jitsi-meet/blob/master/config.js#L313-L327)

Thank you!