### PR TITLE
Add Contributor Metrics Widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Rocket Chat for Virtual Conferences a.k.a __RC4Confernces__ (in short) is a set 
 
 Got questions? Or want to discuss any idea for the project, feel free to drop by and say "Hi": [Rocket.Chat](https://open.rocket.chat/direct/evan.shu), [Gmail](mailto:sdevanshu90@gmail.com)
 
+<a href="https://github.com/monoclehq">
+    <img src="https://open-source-assets.middlewarehq.com/svgs/RocketChat-RC4Conferences-contributor-metrics-dark-widget.svg"/>
+</a>
+
 ## Table of Contents
 
 - [ Installation](#installation)


### PR DESCRIPTION
# Why Do why need this ?

- Contributor recognition can help develop an active opensource community around projects.
-  A widget showcasing recent contributions can be motivating for new contributors. 
- This widget was initially rendered for [https://github.com/RocketChat/Apps.Github22](GitHub RocketChat App) but it was suggested by @Sing-Li  that it can help benefit other community projects. [Link to the comment](https://github.com/RocketChat/Apps.Github22/pull/72#pullrequestreview-1354824996)

# Proposed Changes 

- Add a contributor widget hosted by [Middleware](https://www.middlewarehq.com/) that updates the contributor statistics daily and renders updated widget.
- The Widget is served via a CDN and is updated regularly based on contributor statistics over the last 3 months.
- ![image](https://user-images.githubusercontent.com/70485812/233446712-799a1cc4-f167-4847-bb4d-26b0467923d8.png)

